### PR TITLE
Updated Gemfile a bit more to fix rails console errors and Shogun gem issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'shogun', github: 'getshogun/shogun_rails'
 gem 'uglifier', '>= 1.3.0'
 group :development do
   gem 'better_errors'
+  gem 'dotenv-rails'
   gem 'html2haml'
   gem 'quiet_assets'
   gem 'rails_layout'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
       rack (>= 0.9.0)
-    binding_of_caller (0.7.2)
+    binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
@@ -74,9 +74,13 @@ GEM
     columnize (0.9.0)
     concurrent-ruby (1.1.2)
     crass (1.0.4)
-    debug_inspector (0.0.2)
+    debug_inspector (0.0.3)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.5.0)
+    dotenv-rails (2.5.0)
+      dotenv (= 2.5.0)
+      railties (>= 3.2, < 6.0)
     erubis (2.7.0)
     execjs (2.5.2)
     ffi (1.9.25)
@@ -203,7 +207,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
-    web-console (2.2.1)
+    web-console (2.3.0)
       activemodel (>= 4.0)
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
@@ -217,6 +221,7 @@ DEPENDENCIES
   bootstrap-sass
   byebug
   coffee-rails (~> 4.1.0)
+  dotenv-rails
   haml-rails
   high_voltage
   html2haml


### PR DESCRIPTION
Currently, the app will run and deploy on Heroku, but locally, things like `rails console` will not work, and reading ENV files from `.env` will not work as well. This fixes both of those things.